### PR TITLE
Fixed Broken Links in Documentation

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -39,8 +39,8 @@ If you need to use a license that is not included in either section, please open
 
 # Getting started
 
-- Read the [get started](docs/development/prepare-for-development.md) for developing code for Volcano
-- Read the [setup](docs/development/development.md) for build/deploy instructions.
+- Read the [get started](https://volcano.sh/en/docs/installation/#prerequisites) for developing code for Volcano
+- Read the [setup](https://volcano.sh/en/docs/installation/#install-from-code) for build/deploy instructions.
 
 
 # Your First Contribution


### PR DESCRIPTION
While conducting research for the LFX Mentorship program, I discovered several links that were not functioning. 
I have replaced them with what I believe are the correct ones, though I am not entirely sure. Further verification may be needed.
