### PR TITLE
Update adopter group governence

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter-group-application.yaml
+++ b/.github/ISSUE_TEMPLATE/adopter-group-application.yaml
@@ -1,0 +1,82 @@
+name: Volcano Adopter Group Membership Request
+description: Use this form to apply for joining the Volcano Adopter Group.
+title: "Volcano Adopter Group Application for [Your Name]"
+labels: ["area/github-membership", "adopter-group-membership"]
+assignees:
+  - Monokaix
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your interest in joining the Volcano Adopter Group!
+        Please fill out this form with all the necessary information.
+        The project maintainers will review your application and get back to you shortly.
+  - type: input
+    id: developer-name
+    attributes:
+      label: Your Name
+      description: Please enter your full name.
+      placeholder: ex. Arya Stark
+    validations:
+      required: true
+  - type: input
+    id: company-name
+    attributes:
+      label: Company Name
+      description: Please enter the name of your company or organization.
+      placeholder: ex. AwesomeCorp
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Email
+      description: The email address you want to use for joining the Volcano Adopter mail group. Please use `[at]` instead of `@` to hide your email address from crawlers.
+      placeholder: ex. example[at]awesomecorp.com
+    validations:
+      required: true
+  - type: input
+    id: github-id
+    attributes:
+      label: GitHub ID
+      description: The GitHub ID for joining the volcano-adopter-group team on GitHub.
+      placeholder: ex. @example_user
+    validations:
+      required: true
+  - type: input
+    id: volcano-version
+    attributes:
+      label: Current Volcano Version in Use
+      description: Please specify the version of Volcano you are currently using.
+      placeholder: ex. v1.11.1
+    validations:
+      required: true
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: Requirements(Things that you are recommended to do along with the application)
+      options:
+        - label: I have reviewed the [Volcano Adopter Group guidelines](https://github.com/volcano-sh/community/blob/main/adopter-group/README.md)
+          required: true
+        - label: I have watched volcano-sh/volcano on GitHub to subscribe updates (My account appears in the [watchers list](https://github.com/volcano-sh/volcano/watchers))
+          required: true
+        - label: I have [enabled 2FA on my GitHub account](https://help.github.com/en/github/authenticating-to-github/about-two-factor-authentication)
+          required: true
+        - label: I have subscribed to the [Volcano mailing list](https://groups.google.com/forum/#!forum/volcano-sh)
+          required: true
+        - label: "Ensure your [affiliation in gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#addingupdating-affiliation) is up to date (gitdm is used by [devstats](https://k8s.devstats.cncf.io/) to track affiliation)"
+          required: true
+        - label: "Ensure your [affiliation in openprofile.dev](https://openprofile.dev/edit/profile) is up to date (used by [LFX Insights](https://insights.lfx.dev/) to track affiliation, will replace gitdm in the future)"
+          required: true
+  - type: checkboxes
+    id: process-tracking
+    attributes:
+      label: Application Process Tracking (For Maintainers)
+      description: Tasks for maintainers to get you on board.
+      options:
+        - label: "[Maintainer] Verify applicant identity and information completeness"
+          required: false
+        - label: "[Maintainer] Invite applicant to [the Volcano Adopter mail group](https://groups.google.com/g/volcano-adopter-group)"
+          required: false
+        - label: "[Maintainer] Invite applicant to the Volcano Adopter GitHub team"
+          required: false

--- a/.github/ISSUE_TEMPLATE/adopter-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/adopter-onboarding.md
@@ -1,0 +1,34 @@
+---
+name: Adopter Onboarding
+title: Adopter Onboarding for <name>
+about: Create a checklist of tasks for an organization to complete the onboarding process
+---
+
+Welcome to Volcano Adopters Onboarding!
+
+This is an issue created to help onboard your organization as a [Volcano Adopter](https://github.com/volcano-sh/community/blob/master/adopters.md).
+
+We encourage your organization to complete onboarding within one week of acceptance.
+
+Please track your progress by using "Quote reply" to create your own copy of this checklist in an issue, so that you can update the status as you finish items.
+
+**Things that Volcano will need from your organization:**
+
+- [ ] Name of your organization or company
+- [ ] Link to your website
+- [ ] Your country
+- [ ] Your contact info (such as Email, Twitter, WeChat)
+- [ ] Usage scenario
+- [ ] Usage stage (evaluating, production)
+- [ ] Logo (Optional, this will not be used for commercial purposes.)
+- [ ] Whether your organization needs help from the community
+
+To complete the above information, please leave a comment on this [issue](https://github.com/volcano-sh/volcano/issues/3855).
+
+**Things that your organization needs to do or the Volcano community will help to do:**
+
+- [ ] Edit the list of adopters in [adopters.md](https://github.com/volcano-sh/community/blob/master/adopters.md) and open a Pull Request.
+
+After completing all of the above tasks, you can see your organization listed as a Volcano adopter.
+
+Thank you very much for being part of our community - we greatly appreciate your involvement!

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE
+.idea
+.vscode

--- a/adopter-group/README.md
+++ b/adopter-group/README.md
@@ -1,0 +1,103 @@
+# Volcano Adopter Group
+
+The structure and content of this Volcano Adopter Group draw significant inspiration from the [Karmada Adopter Group](https://github.com/karmada-io/community/blob/main/adopter-group/README.md).
+Wording has been adapted or adopted from their document to ensure clarity and consistency for similar concepts.
+We respect and appreciate the contribution of the Karmada community.
+
+## Introduction
+
+The Volcano Adopter Group is a community initiative to foster a welcoming and dynamic environment for individuals and organizations utilizing the Volcano project.
+This group facilitates the sharing of knowledge, best practices, and user experiences. It also provides a platform for users to connect, collaborate on projects, and contribute to the enhancement of Volcano.
+
+## Purpose
+
+The primary objectives of the Volcano Adopter Group are:
+
+* **Share Knowledge:** Enable users to exchange experiences, challenges, and solutions related to Volcano usage.
+* **Promote Collaboration:** Offer a space for users to collaborate, exchange ideas, and address common problems.
+* **Support Users:** Provide resources, tutorials, and guidance to assist users in effectively using Volcano.
+* **Gather Feedback:** Collect user feedback to inform the future development of Volcano.
+* **Increase Engagement:** Enhance engagement within the Volcano community through regular community interactions and discussions.
+
+## Important Considerations
+
+* **Community Focus:** This group's purpose is to foster community and knowledge sharing. It does not grant special privileges or influence over the Volcano project.
+* **Equal Treatment:** The Volcano community is committed to treating all users and contributors equitably.
+* **Community Guidelines:** Members are expected to adhere to the [Volcano community's code of conduct](https://github.com/volcano-sh/community/blob/master/code_of_conduct.md).
+
+## Membership
+
+### Who Can Join?
+
+The Volcano Adopter Group is open to end-users and vendors who are actively using Volcano. This encompasses:
+
+* **End Users:** Organizations that deploy and operate Volcano in their environments.
+* **Vendors:** Companies that offer products or services based on Volcano and have customers utilizing it.
+
+*Note: Community contributions are currently not a prerequisite for joining. However, the community may in the future encourage members to contribute to the Volcano community.*
+
+### How to Join
+
+To become a member of the Volcano Adopter Group, please follow these steps:
+
+* **For the First Member from Your Organization**
+
+    1.  **Leave a Comment on [this issue](https://github.com/volcano-sh/volcano/issues/3855):**
+        - Leave a comment on this issue with the required information.
+
+    2.  **Review and Onboarding:**
+        - Volcano community maintainers will review your application to confirm eligibility.
+        - Upon approval, your organization may be added to the list of [Volcano Adopter Group](https://github.com/volcano-sh/community/blob/master/adopters.md), and you will receive invitations to join the relevant teams and groups.
+
+* **For Additional Members from an Existing Organization**
+
+    1.  **Prepare Information:**
+        - Your name
+        - Your organization's name: Be sure it already present on the [Volcano Adopter Group](https://github.com/volcano-sh/community/blob/master/adopters.md).
+        - Your preferred contact information
+
+    2.  **Submit the Application:**
+        - Option 1: Open an [issue with the template](https://github.com/volcano-sh/community/issues/new?assignees=Monokaix&labels=area%2Fgithub-membership+%2Cadopter-group-membership&projects=&template=adopter-group-application.yaml&title=Volcano+Adopter+Group+Application+for+%5BYour+Name%5D), and fill in required information on the issue.
+        - Option 2: Email the maintainers (cncf-volcano-maintainers@lists.cncf.io) with the information on above.
+
+    3.  **Review and Addition:**
+        - Volcano community maintainers will verify your request and initiate the following onboarding steps:
+          - **Mail Group Registration**: Add you to the `volcano-adopter-group@googlegroups.com` mail group.
+          - **Send GitHub Invitation**: Send an invitation to add you to the volcano-adopter-group team on GitHub.
+        - Upon approval, you will be invited to join relevant teams and groups.
+
+## Benefits of Joining
+
+Membership in the Volcano Adopter Group provides several benefits:
+
+* **Community Recognition:** Visibility within the Volcano community, and your company's profile will be featured on the list of [Volcano Adopter Group](https://github.com/volcano-sh/community/blob/master/adopters.md).
+* **Networking Opportunities:** Connections with other Volcano users, developers, and enthusiasts.
+* **Experience Sharing:** Opportunities to share and learn from user stories and best practices.
+* **Event Participation:** Invitations to participate in Volcano-related events, including KubeCon + CloudNativeCon, webinars, and meetups.
+* **Community Participation:** Opportunities to engage in community activities and discussions.
+
+## Communication and Meetings
+
+Currently, we do not have a fixed meeting schedule. We encourage adopter members to voluntarily request and host meetings.
+These meetings can be held monthly, quarterly, or as needed, depending on the preferences expressed by the group members. The format and frequency of these meetings will be determined based on community input.
+
+## Exit Mechanism
+
+The Volcano community will establish a transparent process for members to leave the Adopter Group if desired.
+The community also reserves the right to remove members who violate community guidelines.
+
+## Usage of Adopter Group Information
+
+* **Public Sharing:** With consent, the community may share organizational information (e.g. company name, company logo, company website, etc.) and use cases in public forums (such as blogs, conferences, social media, etc.). **However, we will not publicly share any personal information**.
+* **Prohibition of Commercial Use:** Adopter Group information is for community engagement and promotion, **not for commercial use**.
+* **Intellectual Property Protection:** Submissions must comply with relevant laws, regulations and open-source licenses.  (If your submission includes third-party intellectual property, ensure that you have obtained the necessary authorization or permission.)
+* **Privacy Protection:** We take your privacy seriously. All personal data (such as names, email addresses, GitHub IDs, etc.) will be used solely for internal communication and management purposes and will not be disclosed or shared with third parties unless you explicitly consent.
+* **Adherence to Community Guidelines:** As a member of the Volcano Adopter Group, you are expected to adhere to [the community's code of conduct](https://github.com/volcano-sh/community/blob/master/code_of_conduct.md) and guidelines. Respect the rights and opinions of other members and actively participate in healthy discussions and collaborations.
+
+## Contact Information
+
+For inquiries regarding the Volcano Adopter Group, please contact the Volcano community through the following channels:
+
+- **Maintainer Mailing List**: [cncf-volcano-maintainers@lists.cncf.io](mailto:cncf-volcano-maintainers@lists.cncf.io)
+
+*Note: This document is subject to updates based on community feedback and evolving needs.*

--- a/community-building-program.md
+++ b/community-building-program.md
@@ -1,32 +1,11 @@
-## Introduction
-In order to help users quickly integrate into the community, accelerate implementation, and jointly create a prosperous community ecology, the Volcano community is now launching the Volcano community co-construction plan. Through the Volcano community co-construction plan, you will receive support such as technical guidance, publicity and promotion, and opportunities for online/offline technical evangelism and sharing! If your company or organization recognizes Volcano's technical route, hopes to get help in the process of using Volcano, and intends to build technical influence with the Volcano community, please consider joining the program.
+# Migration of Volcano Community Building Program to Adopter Group
 
-## Joining the program will get following benefits.
-- Free training opportunities from the community:
-    - Open source community basic knowledge training, including community governance structure introduction, community development model introduction, open source contribution guidance, etc.
-    - Volcano advanced knowledge training, including architecture and function introduction, analysis of the latest version, etc.
-- Offline Communication Opportunities:
-    - Communication and analysis against user's special scenario, directly attacking problems and protecting project privacy.
-    - Analysis of difficult problems during the landing process to improve the efficiency of resolution.
-    - Direct feedback on technical iteration requirements for faster response.
-- Opportunities to publicize in official media:
-    - Selected projects will be displayed on the official platform.
-    - During the landing process, the community will assist in media promotion at milestone nodes.
-- Opportunities to increase technology impact:
-    - After the project is completed and implemented, the main contributors will receive a community thank you letter.
-    - Opportunity to display the company (or organization) Logo on the official [website](https://volcano.sh/en/).
-    - Online/offline technology sharing opportunities.
-    - Opportunity to speak at the Volcano session at KubeCon.
-    - Opportunity to jointly host community events such as technical summits, salons, meetups, etc.
+**Dear Volcano Community Users:**
 
-## Requirement
-- Willing to follow the Volcano community [code of conduct](https://github.com/volcano-sh/volcano/blob/2734a21bb4df0860257c1238cc9f3e7c5ff32705/code_of_conduct.md)
-- Agree with the open source culture, be willing to communicate, share and collaborate in the community, and respect the contributions of others.
-- Two or more Volcano community members.
-- Recognize the Volcano technology route, plan to participate in community contribution deeply. It will be great to have one or more following practices.
-    - Landing Volcano in a production environment.
-    - Release commercial products based on Volcano that can be delivered to customers.
-    - Provide customers with Volcano technical consulting services.
-    - Use Volcano as a research object.
+Please be advised that the Volcano Community Building Program has been migrated and is now the **Volcano Adopter Group**.
 
-For any questions and problems, please contact the [Volcano community Maintainer](https://github.com/volcano-sh/volcano/blob/master/MAINTAINERS.md).
+The goals and benefits of the former program will continue under the framework of the Adopter Group, which aims to recognize and support organizations and individuals actively using Volcano.
+
+**For more details about the Volcano Adopter Group, including how to join, please refer to the [Volcano Adopter Group](adopter-group/README.md).**
+
+We encourage your continued participation in the Volcano community through the Adopter Group!


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it:**

Volcano previously had a community co-building program. To further enhance engagement with community users and onboard more adopters,  and make the adopter relavant process more clear and transparenty, we are updating the Adopters Recruiting and Onboarding Process and integrating the co-building programinto the adopter process.

**Which issue(s) this PR fixes:**
Fixes #72 

**Special notes for your reviewer:**

Things need to be done along with this proposal:

- [ ]  Mail Group, named **volcano-adopter-group@googlegroups.com**
- [ ]  GitHub team, named **volcano-adopter-group**

Vote from maintainers:

- [x] @kevin-wangzefeng 
- [x] @k82cn 
- [x] @william-wang 
- [x] @Thor-wl 
- [x] @shinytang6 
- [x] @hzxuzhonghu 
