### PR TITLE
docs(adopters): add Aumovio as production adopter

### DIFF
--- a/adopters.md
+++ b/adopters.md
@@ -34,3 +34,4 @@ please feel free to add yourself into the following list by a pull request. Ther
 | [Momenta](https://www.momenta.cn/) | [@houyuting](https://github.com/houyuting) | Production | Use Volcano to run Big data workloads efficiently with Queue/Volcano job, etc. |
 | [Infrawaves](http://infrawaves.com/) | [@buliangjunpp](https://github.com/buliangjunpp) | Production | Leveraging Volcano to run AI/ML workloads efficiently using features like Queues and Volcano Jobs. |
 | [Zoom](https://www.zoom.com/) | [@dafu-wu](chengyi.wu@zoom.com) | Production | Using Volcano to queue/preempt/reclaim jobs in kubeflow. |
+| [Aumovio](https://aumovio.com/) | [@hajnalmt](https://github.com/hajnalmt) | Production | Multi-tenancy management with Queues, leveraging reclaim and preemption for K8s and Kubeflow jobs. |


### PR DESCRIPTION
Aumovio migrated all of its on premise workloads to be managed by volcano. 🍾 🎉 

## Summary
- Add Aumovio to the Volcano adopters list in production.
- Include company website and contact handle.
- Describe usage for multi-tenancy with Queues and reclaim/preempt for Kubernetes and Kubeflow jobs.