### PR TITLE
docs: improve CLOMonitor contributing detection and dependency policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing to the Volcano community
+
+Please read the [Contributor Guide](contribute.md) for how to contribute to Volcano,
+including the contribution workflow, code review, and testing expectations.
+
+For code changes in the main project, see the [Volcano repository](https://github.com/volcano-sh/volcano).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you have any question, feel free to reach out to us in the following ways:
 
 [Twitter](https://twitter.com/volcano_sh)
 
-## Contribute
+## Contributing
 
 The [Contributor Guide](./contribute.md) provides detailed instruction on how to get your ideas and bug fixes seen and accepted, including:
 

--- a/dependency-management.md
+++ b/dependency-management.md
@@ -1,0 +1,40 @@
+# Dependency management policy
+
+This document describes how the Volcano project manages software dependencies.
+It applies to the primary code repository [volcano-sh/volcano](https://github.com/volcano-sh/volcano)
+and related subprojects under the [volcano-sh](https://github.com/volcano-sh/) organization.
+
+## Declaring dependencies
+
+- Go modules in `go.mod` and `go.sum` are the source of truth for Volcano core dependencies.
+- Staging API dependencies are declared in `staging/src/volcano.sh/apis/go.mod` and `go.sum`.
+- Contributors must follow the [license compliance rules](compliance.md#rules) when adding or updating dependencies.
+
+## Updating dependencies
+
+- [Dependabot](https://github.com/volcano-sh/volcano/blob/master/.github/dependabot.yml) proposes updates to Go modules and GitHub Actions dependencies.
+- Maintainers review and merge dependency update pull requests using the normal [contribution workflow](contribute.md#contributor-workflow).
+- Release timing and stabilization windows are described in the [version release policy](version-release.md).
+
+## License and compliance
+
+- Allowed and restricted licenses are defined in [compliance.md](compliance.md#license-compliance-check).
+- License scanning in CI is configured in the Volcano repository (for example, FOSSA and license lint workflows).
+
+## Security vulnerabilities in dependencies
+
+- Report security issues privately as described in [SECURITY.md](SECURITY.md#private-disclosure-processes).
+- The [Product Security Team (PST)](PST.md) coordinates fixes and releases when a dependency-related vulnerability affects Volcano.
+
+## Release supply chain information
+
+- Official releases are published on the [Volcano GitHub releases](https://github.com/volcano-sh/volcano/releases) page.
+- Release artifacts and distribution points are documented in Volcano’s [SECURITY-INSIGHTS.yml](https://github.com/volcano-sh/volcano/blob/master/SECURITY-INSIGHTS.yml) when present on the default branch.
+- SPDX software bill of materials (SBOM) archives may be attached to versioned releases for users and scanners to inspect included components.
+
+## Related documents
+
+- [Contributor Guide](contribute.md)
+- [Security release process](SECURITY.md)
+- [Open source compliance](compliance.md)
+- [Version release policy](version-release.md)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR is part of the work for [volcano-sh/volcano#5366](https://github.com/volcano-sh/volcano/issues/5366) (improve CLOMonitor score). It addresses **community repository** items from that issue:

- **Contributing guide detection:** Add [`CONTRIBUTING.md`](CONTRIBUTING.md) as a pointer to [`contribute.md`](contribute.md). Rename the README section to **Contributing** so CLOMonitor can detect it.
- **Dependency management policy:** Add [`dependency-management.md`](dependency-management.md) describing how Volcano declares, updates, and reports on dependencies. This file is intended to be linked from `SECURITY-INSIGHTS.yml` in the main repo for the CLOMonitor `dependencies_policy` check.

Docs-only change in `volcano-sh/community`. Does not overlap with [volcano-sh/volcano#5369](https://github.com/volcano-sh/volcano/pull/5369), [#5370](https://github.com/volcano-sh/volcano/pull/5370), [#5371](https://github.com/volcano-sh/volcano/pull/5371), or [volcano-sh/website#517](https://github.com/volcano-sh/website/pull/517).

**Follow-up for full `dependencies_policy` pass:** Please add `dependencies.env-dependencies-policy.policy-url` in [volcano-sh/volcano#5367](https://github.com/volcano-sh/volcano/pull/5367) (or a follow-up) pointing at `https://github.com/volcano-sh/community/blob/master/dependency-management.md`.

The **summary table** CLOMonitor check still requires `summary_*` fields in [cncf/landscape](https://github.com/cncf/landscape) (not this repo).

#### Which issue(s) this PR fixes:

Part of volcano-sh/volcano#5366

#### Special notes for your reviewer:

- No workflow, Go, or runtime changes.
- After merge, CLOMonitor checks on this repo may take up to about an hour to refresh.
- `dependencies_policy` on the Volcano project will not pass until the Security Insights URL above is merged in `volcano-sh/volcano`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```