### PR TITLE
docs: add Feedzai as an adopter of volcano

### DIFF
--- a/adopters.md
+++ b/adopters.md
@@ -35,3 +35,4 @@ please feel free to add yourself into the following list by a pull request. Ther
 | [Infrawaves](http://infrawaves.com/) | [@buliangjunpp](https://github.com/buliangjunpp) | Production | Leveraging Volcano to run AI/ML workloads efficiently using features like Queues and Volcano Jobs. |
 | [Zoom](https://www.zoom.com/) | [@dafu-wu](chengyi.wu@zoom.com) | Production | Using Volcano to queue/preempt/reclaim jobs in kubeflow. |
 | [Aumovio](https://aumovio.com/) | [@hajnalmt](https://github.com/hajnalmt) | Production | Multi-tenancy management with Queues, leveraging reclaim and preemption for K8s and Kubeflow jobs. |
+| [Feedzai](https://www.feedzai.com/) | [@devzizu](https://github.com/devzizu) | Production | Leveraging Volcano batch-scheduling and multi-tenancy capabilities to run large-scale AI/ML workloads efficiently. |


### PR DESCRIPTION
## Summary

Adds [Feedzai](https://www.feedzai.com/) as an adopter of Volcano, alongside the use-case and contact details.
