### PR TITLE
Add Pinterest to adopters

### DIFF
--- a/adopters.md
+++ b/adopters.md
@@ -37,3 +37,4 @@ please feel free to add yourself into the following list by a pull request. Ther
 | [Aumovio](https://aumovio.com/) | [@hajnalmt](https://github.com/hajnalmt) | Production | Multi-tenancy management with Queues, leveraging reclaim and preemption for K8s and Kubeflow jobs. |
 | [Feedzai](https://www.feedzai.com/) | [@devzizu](https://github.com/devzizu) | Production | Leveraging Volcano batch-scheduling and multi-tenancy capabilities to run large-scale AI/ML workloads efficiently. |
 | [Zuoyebang](https://zuoyebang.com/) | [@ruanwenjun](https://github.com/ruanwenjun) | Production | Using Volcano to schedule Spark workloads on Kubernetes with queue management, gang scheduling, and job priorities. |
+| [Pinterest](https://www.pinterest.com/) | [@lixmgl](https://github.com/lixmgl) | Production | Using Volcano to queue, preempt, and reclaim Ray jobs on K8s. |


### PR DESCRIPTION
## What changed

- Add Pinterest to the Volcano adopters list.
- Record its production use of Volcano for queueing, preempting, and reclaiming Ray jobs on Kubernetes.

## Why

Pinterest shared its adoption details in volcano-sh/volcano#3855 and requested community guidance on its use case.

Closes #159

## Validation

- `git diff --check`